### PR TITLE
Add testing details and commands for HTTP endpoints.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ FROM ubuntu:latest
 RUN apt update -y && apt upgrade -y
 RUN apt install -y software-properties-common g++ libboost-dev nlohmann-json3-dev libmosquitto-dev 
 RUN add-apt-repository ppa:pistache+team/unstable && apt update -y && apt install -y libpistache-dev
+RUN apt update -y && apt install -y mosquitto mosquitto-clients
 
 # Debugging
-RUN apt install -y curl wget nmap
+RUN apt install -y curl wget nmap vim
 
 # Compile
 COPY . /app
@@ -18,6 +19,6 @@ RUN chmod 755 ./main
 COPY ./delay.sh /delay.sh
 RUN chmod 755 /delay.sh
 EXPOSE 9080
-RUN useradd -m dorel
-USER dorel
+RUN useradd -m mock_user
+USER mock_user
 CMD ["/delay.sh", "1", "./main"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+version=latest
+
+build:
+	docker image build -t smart_kettle_img:latest .
+
+# `-p` exposes the port outside the Docker container 
+run: build
+	docker run -it -p 9080:9080 --name smart_kettle smart_kettle_img:${version} /bin/bash
+
+test:
+	curl -X GET http://localhost:9080/boilLiquidByViscosity
+
+clean:
+	docker rm -f smart_kettle
+
+clean_all:
+	docker rm -f smart_kettle
+	docker image rm smart_kettle_img:${version}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ sudo apt-get install nlohmann-json3-dev
 sudo add-apt-repository ppa:pistache+team/unstable
 sudo apt update
 sudo apt install libpistache-dev
+
+// Mosquitto (MQTT)
+sudo apt install mosquitto mosquitto-clients
 ```
 
 ### Compile and run
@@ -27,15 +30,47 @@ g++ smart_kettle.cpp -o main -lpistache -lmosquitto -lcrypto -lssl -lpthread  -s
 ./main
 ```
 
-### HHTP
+### Test with Docker
+One can build and test the app using Docker. Inside the repo, you can find a `Dockerfile` and a `Makefile` for convenience.
+
+To build the Docker image locally run:
+```bash
+$ make
+```
+
+View the available images with:
+```bash
+$ docker image ls
+```
+
+To run a container that has all the dependencies installed and the app compiled run:
+```bash
+$ make run
+```
+
+### HTTP
 
 #### 1. Warm liquid at the specified temperature
 
 GET /warmLiquid/temperature/scale
 
+```bash
+curl -X GET http://localhost:9080/warmLiquid/80/celsius
+```
+
+```json
+{
+  "message": "Kettle settings saved. The water is warming at 80 degrees celsius",
+  "timestamp": "Tue Jul 13 10:08:29 2021"
+}
+```
 #### 2. Find the viscosity of the containing liquid and set the recommended boiling temperature
 
 GET /boilLiquidByViscosity
+
+```bash
+curl -X GET http://localhost:9080/boilLiquidByViscosity
+```
 
 The kettle uses the information from the viscosity sensor to find the optimal temperature of the containing liquid.
 
@@ -49,7 +84,11 @@ The kettle uses the information from the viscosity sensor to find the optimal te
 #### 3. Make tea
 
 POST /makeTea
-<hr/>
+
+```bash
+curl -H "Content-Type: application/json" -X POST -d '{"keepWarm":'true', "temperature": {"temperature":"100", "scale":"C"}, "time":'5'}' http://localhost:9080/makeTea
+```
+
 The kettle boils the water to the specified temperature, inserts the tea infuser into the water for a certain amount of time and after the infusion it keeps your tea warm.
 
 Input format:
@@ -77,7 +116,10 @@ Output format:
 #### 4. Set a recurrent boiling schedule
 
 POST /warmLiquidByDate
-<hr/>
+
+```bash
+curl -H "Content-Type: application/json" -X POST -d '{"recurrent":'true', "temperature": {"temperature":"30", "scale":"F"}, "hour":"22:30"}' http://localhost:9080/warmLiquidByDate
+```
 
 Set a recurring event if you want to prepare your drink at a certain hour of the day.
 
@@ -107,19 +149,19 @@ Output format:
 #### 5. Stir the liquid at the specified rpm
 
 GET /stirLiquid/rmp
-<hr/> 
-
-
-### MQTT
-
-#### 1. Required libraries
 
 ```bash
-sudo apt install mosquitto
-sudo apt install mosquitto-client
+curl -X GET http://localhost:9080/stirLiquid/1000
 ```
 
-#### 2. Interacting with the device
+```json
+{
+  "message": "Started stirring the content of the kettle at 1000 rmp",
+  "timestamp": "Tue Jul 13 11:25:08 2021"
+}
+```
+
+### MQTT
 
 1. Warm tea
 
@@ -133,12 +175,11 @@ mosquitto_sub -t kettle/temp/70/C -C 1
 mosquitto_sub -t kettle/scheduler -C 1
 ```
 
-3. Get viscosity of the coWntaining liquid and the recommended temperature
+3. Get viscosity of the containing liquid and the recommended temperature
 
 ```bash
 mosquitto_sub -t kettle/viscosity -C 1
 ```
-
 
 ### Team Members
 <hr/>
@@ -149,6 +190,3 @@ mosquitto_sub -t kettle/viscosity -C 1
 - Nazare Daniela Andreea
 - Rusu Iuliana
 - Talmacel Sergiu-Victor
-
-
-


### PR DESCRIPTION
This PR:
- installs mosquito (for MQTT) within the Docker image
- provides a Makefile to build and run the Docker container
- adds details in the Readme on how to test the endpoints with `curl`